### PR TITLE
Removes dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: bundler
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
This is not a live service and it's a hassle to update.